### PR TITLE
Requirements updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN useradd -m -u $UID -g $GID -s /bin/bash murphy
 
 # set up requirements
 WORKDIR /home/murphy
-ADD --chown=murphy:murphy ./requirements.txt /home/murphy/requirements.txt
-RUN pip install -r /home/murphy/requirements.txt
+ADD --chown=murphy:murphy ./requirements-lock.txt /home/murphy/requirements-lock.txt
+RUN pip install -r /home/murphy/requirements-lock.txt
 
 # get package
 ADD --chown=murphy:murphy . .

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# simple-kp
+
+## testing
+
+```bash
+python -m pytest --cov=simple_kp --cov=term-missing tests/
+```

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import sys
+import os
+
+
+def print_green(s):
+    GREEN = '\033[92m'
+    ENDC = '\033[0m'
+    print(f"{GREEN}{s}{ENDC}")
+
+
+def run_command(cmd):
+    print_green(cmd)
+    os.system(cmd)
+
+
+def lock(extra_args):
+    """
+    Write requirements-lock.txt and requirements-test-lock.txt
+    """
+    requirements_files = {
+        "requirements.txt": "requirements-lock.txt",
+        "requirements-test.txt": "requirements-test-lock.txt",
+    }
+
+    for src, locked in requirements_files.items():
+        command = f"""\
+        docker run -v $(pwd):/app python:3.9 \
+            /bin/bash -c "pip install -qqq -r /app/{src} && pip freeze" > {locked}
+        """
+        run_command(command)
+
+def main():
+    command = sys.argv[1]
+    command_func = globals()[command]
+    extra_args = " " + " ".join(sys.argv[2:])
+    command_func(extra_args)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -3,7 +3,7 @@ click==7.1.2
 fastapi==0.62.0
 h11==0.12.0
 pydantic==1.8.2
-reasoner-pydantic @ git+https://github.com/ranking-agent/reasoner-pydantic@dee9f5f8fc77508f9c3a828dfdd6765e06a36078
+reasoner-pydantic @ git+https://github.com/ranking-agent/reasoner-pydantic@50ecbc9b5c129abbbc876a4113503bf51a1f3fb5
 small-kg @ git+git://github.com/patrickkwang/small-kg@9cfa7ca88e4e74163ebd76b22d26ec3a90a14c1d
 starlette==0.13.6
 typing-extensions==3.10.0.0

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,0 +1,10 @@
+aiosqlite==0.16.0
+click==7.1.2
+fastapi==0.62.0
+h11==0.12.0
+pydantic==1.8.2
+reasoner-pydantic @ git+https://github.com/ranking-agent/reasoner-pydantic@9e41079c9036d360b737bfb4d6f6f9127c433130
+small-kg @ git+git://github.com/patrickkwang/small-kg@9cfa7ca88e4e74163ebd76b22d26ec3a90a14c1d
+starlette==0.13.6
+typing-extensions==3.10.0.0
+uvicorn==0.12.3

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -3,7 +3,7 @@ click==7.1.2
 fastapi==0.62.0
 h11==0.12.0
 pydantic==1.8.2
-reasoner-pydantic @ git+https://github.com/ranking-agent/reasoner-pydantic@9e41079c9036d360b737bfb4d6f6f9127c433130
+reasoner-pydantic @ git+https://github.com/ranking-agent/reasoner-pydantic@dee9f5f8fc77508f9c3a828dfdd6765e06a36078
 small-kg @ git+git://github.com/patrickkwang/small-kg@9cfa7ca88e4e74163ebd76b22d26ec3a90a14c1d
 starlette==0.13.6
 typing-extensions==3.10.0.0

--- a/requirements-test-lock.txt
+++ b/requirements-test-lock.txt
@@ -1,0 +1,23 @@
+asgiar @ git+git://github.com/patrickkwang/asgiar@ee956c00b42d5584e0d82a0f0b4de2373c1a1472
+attrs==21.2.0
+certifi==2020.12.5
+chardet==4.0.0
+codecov==2.1.11
+coverage==5.5
+h11==0.12.0
+httpcore==0.12.3
+httpx==0.16.0
+idna==2.10
+iniconfig==1.1.1
+packaging==20.9
+pluggy==0.13.1
+py==1.10.0
+pyparsing==2.4.7
+pytest==6.2.4
+pytest-asyncio==0.15.1
+pytest-cov==2.12.0
+requests==2.25.1
+rfc3986==1.5.0
+sniffio==1.2.0
+toml==0.10.2
+urllib3==1.26.4

--- a/requirements-test-lock.txt
+++ b/requirements-test-lock.txt
@@ -1,13 +1,11 @@
 asgiar @ git+git://github.com/patrickkwang/asgiar@ee956c00b42d5584e0d82a0f0b4de2373c1a1472
 attrs==21.2.0
 certifi==2020.12.5
-chardet==4.0.0
-codecov==2.1.11
 coverage==5.5
 h11==0.12.0
 httpcore==0.12.3
 httpx==0.16.0
-idna==2.10
+idna==3.1
 iniconfig==1.1.1
 packaging==20.9
 pluggy==0.13.1
@@ -16,8 +14,6 @@ pyparsing==2.4.7
 pytest==6.2.4
 pytest-asyncio==0.15.1
 pytest-cov==2.12.0
-requests==2.25.1
 rfc3986==1.5.0
 sniffio==1.2.0
 toml==0.10.2
-urllib3==1.26.4

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,5 @@ pytest
 pytest-asyncio
 pytest-cov
 requests
+httpx==0.16.0
+asgiar @ git+git://github.com/patrickkwang/asgiar@ee956c00b42d5584e0d82a0f0b4de2373c1a1472

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
-codecov
-pytest
-pytest-asyncio
-pytest-cov
-requests
+codecov==2.1.11
+pytest==6.2.4
+pytest-asyncio==0.15.1
+pytest-cov==2.12.0
+requests==2.25.1
 httpx==0.16.0
 asgiar @ git+git://github.com/patrickkwang/asgiar@ee956c00b42d5584e0d82a0f0b4de2373c1a1472

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,5 @@
-codecov==2.1.11
 pytest==6.2.4
 pytest-asyncio==0.15.1
 pytest-cov==2.12.0
-requests==2.25.1
 httpx==0.16.0
-asgiar @ git+git://github.com/patrickkwang/asgiar@ee956c00b42d5584e0d82a0f0b4de2373c1a1472
+asgiar @ git+git://github.com/patrickkwang/asgiar@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiosqlite==0.16.0
 fastapi==0.62.0
-git+https://github.com/ranking-agent/reasoner-pydantic@v1.0.0#egg=reasoner-pydantic
+git+https://github.com/ranking-agent/reasoner-pydantic@v1.1.1#egg=reasoner-pydantic
 git+git://github.com/patrickkwang/small-kg@main
 uvicorn==0.12.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiosqlite==0.16.0
 fastapi==0.62.0
-git+https://github.com/ranking-agent/reasoner-pydantic@v1.0#egg=reasoner-pydantic
+git+https://github.com/ranking-agent/reasoner-pydantic@v1.0.0#egg=reasoner-pydantic
 git+git://github.com/patrickkwang/small-kg@main
 uvicorn==0.12.3


### PR DESCRIPTION
This fixes a couple issues I noticed:

- The newest version of `httpx` was causing our tests to fail. This pins the version to 0.16
- We were missing ASGIAR in our testing requirements
- reasoner-pydantic was pinned to a branch that no longer exists

This adds a management script to help with locking dependencies as well as explicit lockfiles. Also update to support queries in the TRAPI 1.1 format.